### PR TITLE
feat: Synchronous Disk State Check

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,40 +2,10 @@
 
 
 [[projects]]
-  name = "github.com/devlocker/devproxy"
-  packages = ["devproxy"]
-  revision = "c5444b29b6e6db1308ed9ad4b175b0303ffd5737"
-  version = "0.2.2"
-
-[[projects]]
-  name = "github.com/fatih/color"
-  packages = ["."]
-  revision = "570b54cabe6b8eb0bc2dfce68d964677d63b5260"
-  version = "v1.5.0"
-
-[[projects]]
-  name = "github.com/fsnotify/fsnotify"
-  packages = ["."]
-  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
-  version = "v1.4.7"
-
-[[projects]]
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
-
-[[projects]]
-  name = "github.com/mattn/go-colorable"
-  packages = ["."]
-  revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
-  version = "v0.0.9"
-
-[[projects]]
-  name = "github.com/mattn/go-isatty"
-  packages = ["."]
-  revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
-  version = "v0.0.3"
 
 [[projects]]
   branch = "master"
@@ -49,15 +19,9 @@
   revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
   version = "v1.0.0"
 
-[[projects]]
-  branch = "master"
-  name = "golang.org/x/sys"
-  packages = ["unix"]
-  revision = "ff2a66f350cefa5c93a634eadb5d25bb60c85a9c"
-
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c5a9fb7c0f7c220499ac2425585aaa1b366e40e74c38e14eb5d9211db31dc61f"
+  inputs-digest = "fd56cc1810ff527dc29fa5ac153938af6d8df6a405c953638f1275f24d6073d9"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/tychus/configuration.go
+++ b/tychus/configuration.go
@@ -1,11 +1,11 @@
 package tychus
 
 type Configuration struct {
-	Extensions   []string `yaml:"extensions"`
-	Ignore       []string `yaml:"ignore"`
-	ProxyEnabled bool     `yaml:"proxy_enabled"`
-	ProxyPort    int      `yaml:"proxy_port"`
-	AppPort      int      `yaml:"app_port"`
-	Timeout      int      `yaml:"timeout"`
-	Logger       Logger   `yaml:"-"`
+	AppPort      int
+	Ignore       []string
+	Logger       Logger
+	ProxyEnabled bool
+	ProxyPort    int
+	Timeout      int
+	Wait         bool
 }

--- a/tychus/event.go
+++ b/tychus/event.go
@@ -10,6 +10,8 @@ const (
 	rebuilt
 	changed
 	errored
+	requested
+	unchanged
 )
 
 type event struct {

--- a/tychus/proxy.go
+++ b/tychus/proxy.go
@@ -1,0 +1,168 @@
+package tychus
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+type mode uint32
+
+const (
+	mode_errored mode = 1 << iota
+	mode_paused
+	mode_serving
+)
+
+type proxy struct {
+	config   *Configuration
+	errorStr string
+	mode     mode
+	events   chan event
+	revproxy *httputil.ReverseProxy
+}
+
+// Returns a newly configured proxy
+func newProxy(c *Configuration) *proxy {
+	url, err := url.Parse(fmt.Sprintf("%s:%v", "http://localhost", c.AppPort))
+	if err != nil {
+		c.Logger.Fatal(err)
+	}
+
+	revproxy := httputil.NewSingleHostReverseProxy(url)
+	revproxy.ErrorLog = log.New(ioutil.Discard, "", 0)
+
+	p := &proxy{
+		config:   c,
+		revproxy: revproxy,
+		mode:     mode_paused,
+		events:   make(chan event),
+	}
+
+	return p
+}
+
+func (p *proxy) start() error {
+	server := &http.Server{Handler: p}
+
+	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", "localhost", p.config.ProxyPort))
+	if err != nil {
+		return err
+	}
+	defer listener.Close()
+
+	p.config.Logger.Printf(
+		"Proxing requests on port %v to %v",
+		strconv.Itoa(p.config.ProxyPort),
+		strconv.Itoa(p.config.AppPort),
+	)
+
+	p.serve()
+
+	err = server.Serve(listener)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Proxy the request to the application server.
+//
+// The behavior of this function depends on the mode of the proxy. While
+// serving, should the proxied request return a 502, the request will be
+// retried until a non 502 status code is returned, or the timeout specified in
+// the configuration is reached. Paused has the request wait until the server
+// either moves into serving or erroed mode, or a timeout is reached. While in
+// the errored mode, all requests will return a 500 along with some specified
+// error body.
+func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	p.events <- event{op: requested, info: "Incoming Request"}
+
+	timeout := time.After(time.Second * time.Duration(p.config.Timeout))
+	tick := time.Tick(100 * time.Millisecond)
+
+	ctx := r.Context()
+
+	for {
+		select {
+		case <-tick:
+			if p.mode == mode_paused {
+				continue
+			}
+
+			if p.mode == mode_errored {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(p.errorStr))
+				return
+			}
+
+			writer := &proxyWriter{res: w}
+			p.revproxy.ServeHTTP(writer, r)
+
+			// If the request is "successful" - as in the server responded in
+			// some way, return the response to the client.
+			if writer.status != http.StatusBadGateway {
+				return
+			}
+
+		case <-timeout:
+			p.config.Logger.Print("Timeout reached")
+			w.WriteHeader(http.StatusBadGateway)
+			w.Write([]byte("Connection Refused"))
+
+			return
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (p *proxy) serve() {
+	p.config.Logger.Debug("Proxy: Serving")
+	p.mode = mode_serving
+}
+
+func (p *proxy) pause() {
+	p.config.Logger.Debug("Proxy: Paused")
+	p.mode = mode_paused
+}
+
+func (p *proxy) error(e string) {
+	p.config.Logger.Debug("Proxy: Error Mode")
+	p.mode = mode_errored
+	p.errorStr = e
+}
+
+// Wrapper around http.ResponseWriter. Since the proxy works rather naively -
+// it just retries requests over and over until it gets a response from the app
+// server - we can't use the ResponseWriter that is passed to the handler
+// because you cannot call WriteHeader multiple times.
+type proxyWriter struct {
+	res    http.ResponseWriter
+	status int
+}
+
+func (w *proxyWriter) WriteHeader(status int) {
+	if status == 502 {
+		w.status = status
+		return
+	}
+
+	w.res.WriteHeader(status)
+}
+
+func (w *proxyWriter) Write(body []byte) (int, error) {
+	return w.res.Write(body)
+}
+
+func (w *proxyWriter) Header() http.Header {
+	return w.res.Header()
+}

--- a/tychus/watcher.go
+++ b/tychus/watcher.go
@@ -2,94 +2,56 @@ package tychus
 
 import (
 	"errors"
-	"log"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
-
-	"github.com/fsnotify/fsnotify"
 )
 
 type watcher struct {
-	*fsnotify.Watcher
-	events chan event
+	events  chan event
+	lastRun time.Time
+	scan    chan bool
 }
 
 func newWatcher() *watcher {
-	w, err := fsnotify.NewWatcher()
-	if err != nil {
-		log.Fatal("Could not start watcher")
-	}
-
 	return &watcher{
-		Watcher: w,
 		events:  make(chan event),
+		lastRun: time.Now(),
+		scan:    make(chan bool),
 	}
 }
 
 func (w *watcher) start(c *Configuration) {
-	go w.watchForChanges(c)
-
-	// With the way most editors work, they will generate multiple events on
-	// save. To avoid excessive restarts, batch all messages together within
-	// some interval and notify the orchestrator once per interval.
-	tick := time.Tick(200 * time.Millisecond)
-	events := make([]fsnotify.Event, 0)
-
 	for {
-		select {
-		case event := <-w.Events:
-			if event.Op == fsnotify.Chmod {
-				continue
+		<-w.scan
+
+		c.Logger.Debug("Scan: Start")
+		start := time.Now()
+
+		modified := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
+			if info.IsDir() && w.shouldSkipDir(path, c) {
+				return filepath.SkipDir
 			}
 
-			if w.isWatchedFile(event.Name, c) {
-				events = append(events, event)
-			}
-
-		case <-tick:
-			if len(events) == 0 {
-				continue
-			}
-
-			c.Logger.Debugf("FS Changes: %v", events)
-			w.events <- event{info: "File System Change", op: changed}
-
-			events = make([]fsnotify.Event, 0)
-		}
-	}
-}
-
-// Setup file watchers for all valid extensions and directories.
-func (w *watcher) watchForChanges(c *Configuration) error {
-	for {
-		err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
-			if info == nil {
-				return errors.New("nil directory")
-			}
-
-			if info.IsDir() {
-				if w.shouldSkipDir(path, c) {
-					return filepath.SkipDir
-				}
-
-				c.Logger.Debugf("Watching: %v", path)
-				w.Add(path)
+			if info.ModTime().After(w.lastRun) {
+				return errors.New(path)
 			}
 
 			return nil
 		})
 
-		if err != nil {
-			break
+		c.Logger.Debugf("Scan: took: %v", time.Since(start))
+
+		w.lastRun = time.Now()
+
+		if modified != nil {
+			w.events <- event{op: changed, info: fmt.Sprintf("FS Change: %v", modified)}
+		} else {
+			w.events <- event{op: unchanged, info: "FS Unchanged"}
 		}
-
-		// Walk once a second.
-		time.Sleep(1 * time.Second)
 	}
-
-	return errors.New("Watcher died")
 }
 
 // Checks to see if this directory should be watched. Don't want to watch
@@ -99,27 +61,8 @@ func (w *watcher) shouldSkipDir(path string, c *Configuration) bool {
 		return true
 	}
 
-	for _, f := range c.Ignore {
-		f = strings.TrimSpace(f)
-		f = strings.TrimRight(f, "/")
-
-		if f == path {
-			return true
-		}
-	}
-
-	return false
-}
-
-// Checks to see if path matches a configured extension.
-func (w *watcher) isWatchedFile(path string, c *Configuration) bool {
-	if len(c.Extensions) == 0 {
-		return true
-	}
-
-	ext := filepath.Ext(path)
-	for _, e := range c.Extensions {
-		if e == ext {
+	for _, dir := range c.Ignore {
+		if dir == path {
 			return true
 		}
 	}


### PR DESCRIPTION
Some negatives with the current approach (evented FS watcher)

1. Build loops are possible
   If you forget to ignore something, its possible to get stuck in a
   build loop, where the command outputs a file, which triggers a
   rebuild, which outputs a file, which triggers...

2. CPU usage
   Evented watchers aren't free. Larger the project, the more %CPU it
   takes to just watch the FS

3. Wasted work
   After everysave, a build is triggered - which isn't ideal as in most
   cases one will save more than 1 file before tabbing over to the
   browser. This leads to more wasted CPU spent rerunning commands on
   every save.

New approach: Check FS on HTTP request.

Flipped the sequence. Previously:
-> FS Change
-> Pause Proxy
-> Rebuild
-> Unpause Proxy

New sequence:

-> Request comes in
-> Pause Proxy
-> Check for FS changes
-> If changes exist, rebuild
-> Unpause Proxy

This has several advantages:

1. 0% CPU usage while idle
2. No wasted builds

The obvious downside is that now each request needs to check the FS for
changes.

However, with these changes it is possible to chain multiple `tychus`'s
together. When using that feature, a `--wait` flag has been added. Using
that flag will tell tychus to block until the user specified command
finishes. This command will most often be some script or quick series of
commands and not something blocking like a webserver.